### PR TITLE
Min Torch version updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests==2.32.3
 scikit-learn==1.5.1
 syft==0.9.1
 tabulate==0.9.0
-torch==2.4.1
+torch>=2.2


### PR DESCRIPTION
## Description
Torch version required is now including support for macos with intel chips (which I think is the culprit for Issue #2)

